### PR TITLE
fix(legacy): add memory barrier to avoid some unknown incorrect optimize

### DIFF
--- a/legacy/firmware/near.c
+++ b/legacy/firmware/near.c
@@ -202,6 +202,7 @@ static int borsh_read_buffer(const NearSignTx *msg, uint32_t *buffer_len,
     return -1;
   }
   *buffer = &msg->raw_tx.bytes[*processed];
+  __asm__("" : : "r"(*buffer) : "memory");
   *processed += *buffer_len;
   return 0;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 在 `borsh_read_buffer` 函数中引入了新的内联汇编指令，以确保在读取缓冲区指针时保持内存一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->